### PR TITLE
Reducing the size of logo between 320-337px screen width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -318,7 +318,7 @@ header .jumbotron span{
         width: 80px;
     }
 }
-@media screen and (min-width: 338px){
+@media screen and (min-width: 768px){
 
     /*Navbar Logo Image resize*/
 
@@ -327,7 +327,7 @@ header .jumbotron span{
     }
 
 }
-@media screen and (max-width: 768px){
+@media screen and (max-width: 767px){
 
     /*Media Navbar*/
 

--- a/css/style.css
+++ b/css/style.css
@@ -31,7 +31,8 @@ nav .navbar-collapse {
 }
 
 nav .navbar-brand img {
-    height: 80px;
+    max-width: 220px;
+    max-height: 80px;
     background: #f8f8f8;
     float: left;
     margin: -15px 15px 0 15px;
@@ -317,7 +318,15 @@ header .jumbotron span{
         width: 80px;
     }
 }
+@media screen and (min-width: 338px){
 
+    /*Navbar Logo Image resize*/
+
+    nav .navbar-brand img {
+        max-width: none;
+    }
+
+}
 @media screen and (max-width: 768px){
 
     /*Media Navbar*/

--- a/css/style.css
+++ b/css/style.css
@@ -31,11 +31,11 @@ nav .navbar-collapse {
 }
 
 nav .navbar-brand img {
-    max-width: 220px;
-    max-height: 80px;
+    height: 70px;
     background: #f8f8f8;
     float: left;
-    margin: -15px 15px 0 15px;
+    margin: -10px 15px 0 15px;
+
 }
 
 nav a.navbar-brand {
@@ -292,6 +292,12 @@ header .jumbotron span{
 /*-----------------MEDIA------------------------*/
 @media all and (min-width: 768px) {
 
+    nav .navbar-brand img {
+        height: 80px;
+        margin-top: -15px;
+    }
+
+
     /*Media for Feature-Info*/
     .picture-info img {
         width: 80px;
@@ -318,15 +324,7 @@ header .jumbotron span{
         width: 80px;
     }
 }
-@media screen and (min-width: 768px){
 
-    /*Navbar Logo Image resize*/
-
-    nav .navbar-brand img {
-        max-width: none;
-    }
-
-}
 @media screen and (max-width: 767px){
 
     /*Media Navbar*/


### PR DESCRIPTION
Zmniejszono wielkość loga w navbar na małych rozdzielczościach (pomiędzy 320-337px włącznie) aby usunąć efekt przeskakiwania przycisku menu na niskich rozdzielczościach i powiększania navbara.

Dodano @media oraz max-width/max-height dla tego loga.